### PR TITLE
[POC] Zenject resolver auto binings

### DIFF
--- a/Assets/UniState/Runtime/Integrations/Zenject/ZenjectContainerExtenstion.cs
+++ b/Assets/UniState/Runtime/Integrations/Zenject/ZenjectContainerExtenstion.cs
@@ -25,7 +25,6 @@ namespace UniState
         public static ConcreteIdArgConditionCopyNonLazyBinder BindState(
             this DiContainer container, Type type)
             => container.BindInterfacesAndSelfTo(type).AsTransient();
-        
 
         public static ConcreteIdArgConditionCopyNonLazyBinder BindAbstractState<TInterface, TState>(
             this DiContainer container)

--- a/Assets/UniState/Runtime/Integrations/Zenject/ZenjectContainerExtenstion.cs
+++ b/Assets/UniState/Runtime/Integrations/Zenject/ZenjectContainerExtenstion.cs
@@ -1,5 +1,6 @@
 #if UNISTATE_ZENJECT_SUPPORT
 
+using System;
 using Zenject;
 
 namespace UniState
@@ -20,6 +21,11 @@ namespace UniState
         public static ConcreteIdArgConditionCopyNonLazyBinder BindState<TState>(
             this DiContainer container) =>
             container.BindInterfacesAndSelfTo<TState>().AsTransient();
+
+        public static ConcreteIdArgConditionCopyNonLazyBinder BindState(
+            this DiContainer container, Type type)
+            => container.BindInterfacesAndSelfTo(type).AsTransient();
+        
 
         public static ConcreteIdArgConditionCopyNonLazyBinder BindAbstractState<TInterface, TState>(
             this DiContainer container)

--- a/Assets/UniState/Runtime/Integrations/Zenject/ZenjectTypeResolver.cs
+++ b/Assets/UniState/Runtime/Integrations/Zenject/ZenjectTypeResolver.cs
@@ -8,13 +8,23 @@ namespace UniState
     public class ZenjectTypeResolver : ITypeResolver
     {
         private readonly DiContainer _container;
+        private readonly bool _allowAutoBindings;
 
-        public ZenjectTypeResolver(DiContainer container)
+        public ZenjectTypeResolver(DiContainer container, bool allowAutoBindings)
         {
             _container = container;
+            _allowAutoBindings = allowAutoBindings;
         }
 
-        public object Resolve(Type type) => _container.Resolve(type);
+        public object Resolve(Type type)
+        {
+            if (_allowAutoBindings && !type.IsAbstract && !type.IsInterface && !_container.HasBinding(type))
+            {
+                _container.BindState(type);
+            }
+
+            return _container.Resolve(type);
+        }
     }
 }
 

--- a/Assets/UniState/Runtime/Integrations/Zenject/ZenjectUniStateExtensions.cs
+++ b/Assets/UniState/Runtime/Integrations/Zenject/ZenjectUniStateExtensions.cs
@@ -4,8 +4,9 @@ namespace UniState
 {
     public static class ZenjectUniStateExtensions
     {
-        public static ITypeResolver ToTypeResolver(this Zenject.DiContainer container) =>
-            new ZenjectTypeResolver(container);
+        public static ITypeResolver ToTypeResolver(
+            this Zenject.DiContainer container, bool allowAutoBindings = true)
+            => new ZenjectTypeResolver(container, allowAutoBindings);
     }
 }
 

--- a/Assets/UniStateTests/PlayMode/GoBackTests/GoBackZenjectTests.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackTests/GoBackZenjectTests.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
-using UniState;
 using UniStateTests.Common;
 using UniStateTests.PlayMode.GoBackTests.Infrastructure;
 using UnityEngine.TestTools;
@@ -24,11 +23,6 @@ namespace UniStateTests.PlayMode.GoBackTests
             base.SetupBindings(container);
 
             container.Bind<GoBackFlagsData>().ToSelf().AsSingle();
-
-            container.BindStateMachine<StateMachineGoBack>();
-            container.BindState<StateGoBack1>();
-            container.BindState<StateGoBack2>();
-            container.BindState<StateGoBack3>();
         }
     }
 }


### PR DESCRIPTION
Add auto bind option to ZenjectTypeResolver
This option allows users to skip concrete state and state machine bindings in installers: they will be binded when state machine is created or state is transitioned to for the first time inside of a container's context

This implementation is a proof of concept and may need additional restrictions (e.g. avoid binding non-UniState types)

I'm not sure how to provide same functionality for VContainer, since VContainer's IContainerBuilder doesn't seem to accessible