### PR TITLE
Rework naming with Async suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # AI-related
 CLAUDE.md
+AGENTS.md
+
+# Temp
+TempDotnetTests
+
 
 # This .gitignore file should be placed at the root of your Unity project directory
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# AI-related
+CLAUDE.md
+
 # This .gitignore file should be placed at the root of your Unity project directory
 #
 # Get latest from https://github.com/github/gitignore/blob/master/Unity.gitignore

--- a/Assets/Benchmarks/UniStateFixtures/BarState.cs
+++ b/Assets/Benchmarks/UniStateFixtures/BarState.cs
@@ -14,14 +14,14 @@ namespace Benchmarks.UniStateFixtures
             _benchmarkHelper = benchmarkHelper;
         }
 
-        public override UniTask Initialize(CancellationToken token)
+        public override UniTask InitializeAsync(CancellationToken token)
         {
             _benchmarkHelper.InitializeWasInvoked();
 
             return UniTask.CompletedTask;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _benchmarkHelper.ExecuteWasInvoked();
 
@@ -30,7 +30,7 @@ namespace Benchmarks.UniStateFixtures
                 : Transition.GoTo<FooState>());
         }
 
-        public override UniTask Exit(CancellationToken token)
+        public override UniTask ExitAsync(CancellationToken token)
         {
             _benchmarkHelper.ExitWasInvoked();
 

--- a/Assets/Benchmarks/UniStateFixtures/FooState.cs
+++ b/Assets/Benchmarks/UniStateFixtures/FooState.cs
@@ -14,14 +14,14 @@ namespace Benchmarks.UniStateFixtures
             _benchmarkHelper = benchmarkHelper;
         }
 
-        public override UniTask Initialize(CancellationToken token)
+        public override UniTask InitializeAsync(CancellationToken token)
         {
             _benchmarkHelper.InitializeWasInvoked();
 
             return UniTask.CompletedTask;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _benchmarkHelper.ExecuteWasInvoked();
 
@@ -30,7 +30,7 @@ namespace Benchmarks.UniStateFixtures
                 : Transition.GoTo<BarState>());
         }
 
-        public override UniTask Exit(CancellationToken token)
+        public override UniTask ExitAsync(CancellationToken token)
         {
             _benchmarkHelper.ExitWasInvoked();
 

--- a/Assets/Benchmarks/UniStateFixtures/UniBenchmarkTestBase.cs
+++ b/Assets/Benchmarks/UniStateFixtures/UniBenchmarkTestBase.cs
@@ -21,7 +21,7 @@ namespace Benchmarks.UniStateFixtures
 
             stateMachine.SetResolver(resolver);
 
-            await stateMachine.Execute<FooState>(CancellationToken.None);
+            await stateMachine.ExecuteAsync<FooState>(CancellationToken.None);
         }
 
         public void Clear()

--- a/Assets/Examples/Infrastructure/Reflex/DiceEntryPoint.cs
+++ b/Assets/Examples/Infrastructure/Reflex/DiceEntryPoint.cs
@@ -13,7 +13,7 @@ namespace Examples.Infrastructure.Reflex
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 }

--- a/Assets/Examples/Infrastructure/VContainer/DiceEntryPoint.cs
+++ b/Assets/Examples/Infrastructure/VContainer/DiceEntryPoint.cs
@@ -17,7 +17,7 @@ namespace Examples.Infrastructure.VContainer
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 }

--- a/Assets/Examples/States/LostState.cs
+++ b/Assets/Examples/States/LostState.cs
@@ -8,7 +8,7 @@ namespace Examples.States
 {
     public class LostState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("You lost. You will have a another chance in...");
 

--- a/Assets/Examples/States/RollDiceState.cs
+++ b/Assets/Examples/States/RollDiceState.cs
@@ -9,7 +9,7 @@ namespace Examples.States
 {
     public class RollDiceState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Need to roll 5+. Rolling the dice...");
 

--- a/Assets/Examples/States/StartGameState.cs
+++ b/Assets/Examples/States/StartGameState.cs
@@ -8,7 +8,7 @@ namespace Examples.States
 {
     internal class StartGameState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Welcome to the game! You game will be loaded in 2 seconds!");
 

--- a/Assets/Examples/States/WinState.cs
+++ b/Assets/Examples/States/WinState.cs
@@ -7,7 +7,7 @@ namespace Examples.States
 {
     public class WinState : StateBase
     {
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Congratulations! You won this game!");
 

--- a/Assets/UniState/Runtime/Core/State/DefaultCompositeState.cs
+++ b/Assets/UniState/Runtime/Core/State/DefaultCompositeState.cs
@@ -9,8 +9,8 @@ namespace UniState
 
     public class DefaultCompositeState<TPayload> : CompositeStateBase<TPayload>
     {
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token) => SubStates.Execute(token);
-        public override UniTask Initialize(CancellationToken token) => SubStates.Initialize(token);
-        public override UniTask Exit(CancellationToken token) => SubStates.Exit(token);
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token) => SubStates.ExecuteAsync(token);
+        public override UniTask InitializeAsync(CancellationToken token) => SubStates.InitializeAsync(token);
+        public override UniTask ExitAsync(CancellationToken token) => SubStates.ExitAsync(token);
     }
 }

--- a/Assets/UniState/Runtime/Core/State/Interfaces/IExecutableState.cs
+++ b/Assets/UniState/Runtime/Core/State/Interfaces/IExecutableState.cs
@@ -6,8 +6,8 @@ namespace UniState
 {
     public interface IExecutableState : IDisposable
     {
-        UniTask Initialize(CancellationToken token);
-        UniTask<StateTransitionInfo> Execute(CancellationToken token);
-        UniTask Exit(CancellationToken token);
+        UniTask InitializeAsync(CancellationToken token);
+        UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token);
+        UniTask ExitAsync(CancellationToken token);
     }
 }

--- a/Assets/UniState/Runtime/Core/State/StateBase.cs
+++ b/Assets/UniState/Runtime/Core/State/StateBase.cs
@@ -18,14 +18,14 @@ namespace UniState
         protected IStateTransitionFacade Transition { get; private set; }
         protected List<IDisposable> Disposables => _disposables ??= new(4);
 
-        public abstract UniTask<StateTransitionInfo> Execute(CancellationToken token);
+        public abstract UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token);
 
-        public virtual UniTask Initialize(CancellationToken token)
+        public virtual UniTask InitializeAsync(CancellationToken token)
         {
             return UniTask.CompletedTask;
         }
 
-        public virtual UniTask Exit(CancellationToken token)
+        public virtual UniTask ExitAsync(CancellationToken token)
         {
             return UniTask.CompletedTask;
         }

--- a/Assets/UniState/Runtime/Core/State/SubStatesContainer.cs
+++ b/Assets/UniState/Runtime/Core/State/SubStatesContainer.cs
@@ -23,10 +23,10 @@ namespace UniState
         public void SetTransitionFacade(IStateTransitionFacade transitionFacade) =>
             _subStates.ForEach(s => s.SetTransitionFacade(transitionFacade));
 
-        public UniTask Initialize(CancellationToken token) =>
-            UniTask.WhenAll(List.Select(s => s.Initialize(token)).ToArray());
+        public UniTask InitializeAsync(CancellationToken token) =>
+            UniTask.WhenAll(List.Select(s => s.InitializeAsync(token)).ToArray());
 
-        public async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             if (List.Count == 0)
             {
@@ -38,7 +38,7 @@ namespace UniState
             var ctx = CancellationTokenSource.CreateLinkedTokenSource(token);
             try
             {
-                var first = await UniTask.WhenAny(List.Select(s => s.Execute(ctx.Token)).ToArray());
+                var first = await UniTask.WhenAny(List.Select(s => s.ExecuteAsync(ctx.Token)).ToArray());
                 result = first.result;
             }
             finally
@@ -50,8 +50,8 @@ namespace UniState
             return result;
         }
 
-        public UniTask Exit(CancellationToken token) =>
-            UniTask.WhenAll(List.Select(s => s.Exit(token)).ToArray());
+        public UniTask ExitAsync(CancellationToken token) =>
+            UniTask.WhenAll(List.Select(s => s.ExitAsync(token)).ToArray());
 
         public void Dispose() => _subStates.ForEach(s => s.Dispose());
     }

--- a/Assets/UniState/Runtime/Core/StateMachine/IStateMachine.cs
+++ b/Assets/UniState/Runtime/Core/StateMachine/IStateMachine.cs
@@ -7,8 +7,8 @@ namespace UniState
     {
         bool IsExecuting { get; }
 
-        UniTask Execute<TState>(CancellationToken token) where TState : class, IState<EmptyPayload>;
-        UniTask Execute<TState, TPayload>(TPayload payload, CancellationToken token)
+        UniTask ExecuteAsync<TState>(CancellationToken token) where TState : class, IState<EmptyPayload>;
+        UniTask ExecuteAsync<TState, TPayload>(TPayload payload, CancellationToken token)
             where TState : class, IState<TPayload>;
         void SetResolver(ITypeResolver resolver);
     }

--- a/Assets/UniState/Runtime/Core/StateMachine/StateMachine.cs
+++ b/Assets/UniState/Runtime/Core/StateMachine/StateMachine.cs
@@ -19,12 +19,12 @@ namespace UniState
             _transitionFactory = new StateTransitionFactory(resolver);
         }
 
-        public virtual async UniTask Execute<TState>(CancellationToken token) where TState : class, IState<EmptyPayload>
+        public virtual async UniTask ExecuteAsync<TState>(CancellationToken token) where TState : class, IState<EmptyPayload>
         {
             await ExecuteInternal(_transitionFactory.CreateStateTransition<TState>(), token);
         }
 
-        public virtual async UniTask Execute<TState, TPayload>(TPayload payload, CancellationToken token)
+        public virtual async UniTask ExecuteAsync<TState, TPayload>(TPayload payload, CancellationToken token)
             where TState : class, IState<TPayload>
         {
             await ExecuteInternal(_transitionFactory.CreateStateTransition<TState, TPayload>(payload), token);
@@ -59,9 +59,9 @@ namespace UniState
 
             try
             {
-                await InitializeSafe(activeStateMetadata.State, token);
+                await InitializeSafeAsync(activeStateMetadata.State, token);
 
-                var transitionInfo = await ExecuteSafe(activeStateMetadata.State, token);
+                var transitionInfo = await ExecuteSafeAsync(activeStateMetadata.State, token);
 
                 ProcessTransitionInfo(transitionInfo, activeStateMetadata.TransitionInfo, nextStateMetadata);
 
@@ -69,23 +69,23 @@ namespace UniState
                 {
                     if (nextStateMetadata.BehaviourData.InitializeOnStateTransition)
                     {
-                        await InitializeSafe(nextStateMetadata.State, token);
-                        await ExitAndDisposeSafe(activeStateMetadata.State, token);
+                        await InitializeSafeAsync(nextStateMetadata.State, token);
+                        await ExitAndDisposeSafeAsync(activeStateMetadata.State, token);
                     }
                     else
                     {
-                        await ExitAndDisposeSafe(activeStateMetadata.State, token);
-                        await InitializeSafe(nextStateMetadata.State, token);
+                        await ExitAndDisposeSafeAsync(activeStateMetadata.State, token);
+                        await InitializeSafeAsync(nextStateMetadata.State, token);
                     }
 
                     activeStateMetadata.CopyData(nextStateMetadata);
 
-                    transitionInfo = await ExecuteSafe(activeStateMetadata.State, token);
+                    transitionInfo = await ExecuteSafeAsync(activeStateMetadata.State, token);
 
                     ProcessTransitionInfo(transitionInfo, activeStateMetadata.TransitionInfo, nextStateMetadata);
                 }
 
-                await ExitAndDisposeSafe(activeStateMetadata.State, token);
+                await ExitAndDisposeSafeAsync(activeStateMetadata.State, token);
                 activeStateMetadata.Clear();
             }
             catch (OperationCanceledException)
@@ -153,13 +153,13 @@ namespace UniState
             return null;
         }
 
-        private async UniTask<StateTransitionInfo> ExecuteSafe(IExecutableState state, CancellationToken token)
+        private async UniTask<StateTransitionInfo> ExecuteSafeAsync(IExecutableState state, CancellationToken token)
         {
             try
             {
                 token.ThrowIfCancellationRequested();
 
-                return await state.Execute(token);
+                return await state.ExecuteAsync(token);
             }
             catch (OperationCanceledException)
             {
@@ -173,12 +173,12 @@ namespace UniState
             return BuildRecoveryTransition(_transitionFactory);
         }
 
-        private async UniTask InitializeSafe(IExecutableState state, CancellationToken token)
+        private async UniTask InitializeSafeAsync(IExecutableState state, CancellationToken token)
         {
             try
             {
                 token.ThrowIfCancellationRequested();
-                await state.Initialize(token);
+                await state.InitializeAsync(token);
             }
             catch (OperationCanceledException)
             {
@@ -190,12 +190,12 @@ namespace UniState
             }
         }
 
-        private async UniTask ExitAndDisposeSafe(IExecutableState state, CancellationToken token)
+        private async UniTask ExitAndDisposeSafeAsync(IExecutableState state, CancellationToken token)
         {
             try
             {
                 token.ThrowIfCancellationRequested();
-                await state.Exit(token);
+                await state.ExitAsync(token);
             }
             catch (OperationCanceledException)
             {

--- a/Assets/UniStateTests/Common/StateMachine/StateMachineTestHelper.cs
+++ b/Assets/UniStateTests/Common/StateMachine/StateMachineTestHelper.cs
@@ -12,7 +12,7 @@ namespace UniStateTests.Common
             where TState : class, IState<EmptyPayload>
         {
             var stateMachine = typeResolver.Resolve<TStateMachine>();
-            await stateMachine.Execute<TState>(cancellationToken);
+            await stateMachine.ExecuteAsync<TState>(cancellationToken);
 
             stateMachine.Verify();
         }

--- a/Assets/UniStateTests/EditMode/States/StateDisposablesTests.cs
+++ b/Assets/UniStateTests/EditMode/States/StateDisposablesTests.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.EditMode.Common
     {
         private class DisposablesState : StateBase<IList<IDisposable>>
         {
-            public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+            public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
             {
                 Disposables.AddRange(Payload);
 
@@ -24,9 +24,9 @@ namespace UniStateTests.EditMode.Common
 
         private class ExceptionDisposableState : DisposablesState
         {
-            public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+            public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
             {
-                _ = base.Execute(token);
+                _ = base.ExecuteAsync(token);
 
                 throw new("Test exception");
             }
@@ -57,7 +57,7 @@ namespace UniStateTests.EditMode.Common
             where TState: DisposablesState
         {
             var stateMachine = Container.Resolve<IStateMachine>();
-            stateMachine.Execute<TState, IList<IDisposable>>(disposables, default).GetAwaiter().GetResult();
+            stateMachine.ExecuteAsync<TState, IList<IDisposable>>(disposables, default).GetAwaiter().GetResult();
         }
 
         protected override void SetupBindings(DiContainer container)

--- a/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/FastInitializeState.cs
+++ b/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/FastInitializeState.cs
@@ -15,14 +15,14 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask Initialize(CancellationToken token)
+        public override async UniTask InitializeAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
             _logger.LogStep("FastInitializeState", $"Initialize");
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
@@ -31,7 +31,7 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             return Transition.GoBack();
         }
 
-        public override async UniTask Exit(CancellationToken token)
+        public override async UniTask ExitAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/FirstState.cs
+++ b/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/FirstState.cs
@@ -16,14 +16,14 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             _testHelper = testHelper;
         }
 
-        public override async UniTask Initialize(CancellationToken token)
+        public override async UniTask InitializeAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
             _logger.LogStep("FirstState", $"Initialize");
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
@@ -39,7 +39,7 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             return Transition.GoTo<NoReturnState>();
         }
 
-        public override async UniTask Exit(CancellationToken token)
+        public override async UniTask ExitAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/NoReturnState.cs
+++ b/Assets/UniStateTests/PlayMode/BehaviorAttributeTests/Infrastructure/NoReturnState.cs
@@ -15,14 +15,14 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask Initialize(CancellationToken token)
+        public override async UniTask InitializeAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
             _logger.LogStep("NoReturnState", $"Initialize");
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
@@ -31,7 +31,7 @@ namespace UniStateTests.PlayMode.StateBehaviorAttributeTests.Infrastructure
             return Transition.GoTo<FastInitializeState>();
         }
 
-        public override async UniTask Exit(CancellationToken token)
+        public override async UniTask ExitAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/FirstState.cs
+++ b/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/FirstState.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.Execution.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("FirstState", _machineTestHelper.CurrentStateMachine.IsExecuting.ToString());
 

--- a/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondState.cs
+++ b/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondState.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.Execution.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("SecondState", _machineTestHelper.CurrentStateMachine.IsExecuting.ToString());
 

--- a/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondStateWithException.cs
+++ b/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondStateWithException.cs
@@ -17,14 +17,14 @@ namespace UniStateTests.PlayMode.Execution.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("SecondStateWithException", _machineTestHelper.CurrentStateMachine.IsExecuting.ToString());
 
             return UniTask.FromResult(Transition.GoToExit());
         }
 
-        public override UniTask Exit(CancellationToken token)
+        public override UniTask ExitAsync(CancellationToken token)
         {
             throw new Exception("test exception");
         }

--- a/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondStateWithWrongDependency.cs
+++ b/Assets/UniStateTests/PlayMode/ExecutionTests/Infrastructure/SecondStateWithWrongDependency.cs
@@ -17,7 +17,7 @@ namespace UniStateTests.PlayMode.Execution.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("SecondStateWithWrongDependency",
                 _machineTestHelper.CurrentStateMachine.IsExecuting.ToString());

--- a/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackFirst.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackFirst.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.GoBackTests.Infrastructure
             _goBackFlags = goBackFlags;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoBackFirst", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackSecond.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackSecond.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.GoBackTests.Infrastructure
             _goBackFlags = goBackFlags;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoBackSecond", $"Execute:{Payload}");
 

--- a/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackThird.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackTests/Infrastructure/StateGoBackThird.cs
@@ -13,7 +13,7 @@ namespace UniStateTests.PlayMode.GoBackTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoBackThird", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState1.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState1.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.GoBackToTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep(nameof(GoBackToState1), "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState2.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState2.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.GoBackToTests.Infrastructure
             _helper = helper;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep(nameof(GoBackToState2), $"Execute:{Payload}");
             

--- a/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState3.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState3.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.GoBackToTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep(nameof(GoBackToState3), "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState4.cs
+++ b/Assets/UniStateTests/PlayMode/GoBackToTests/Infrastructure/GoBackToState4.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.GoBackToTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep(nameof(GoBackToState4), "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/CompositeStateGoTo6.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/CompositeStateGoTo6.cs
@@ -20,7 +20,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("SubStateGoTo6First", "Execute");
 
@@ -40,7 +40,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/CompositeStateGoTo7.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/CompositeStateGoTo7.cs
@@ -19,7 +19,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("SubStateGoTo7First", $"Execute:{Payload.DelayFirstSubState}");
 
@@ -48,7 +48,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo1.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo1.cs
@@ -13,7 +13,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo1", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo2.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo2.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo2", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo3.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo3.cs
@@ -17,7 +17,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo3", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo4.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo4.cs
@@ -18,7 +18,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo4", "Execute");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo5.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo5.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo5", $"Execute:{Payload.Value}");
 

--- a/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo8.cs
+++ b/Assets/UniStateTests/PlayMode/GoToStateTests/Infrastructure/StateGoTo8.cs
@@ -18,7 +18,7 @@ namespace UniStateTests.PlayMode.GoToStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             _logger.LogStep("StateGoTo8", $"Execute:{Payload}");
 

--- a/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateBarHistory.cs
+++ b/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateBarHistory.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.HistoryTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateFooHistory.cs
+++ b/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateFooHistory.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.HistoryTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateInitLongHistory.cs
+++ b/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateInitLongHistory.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.HistoryTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateInitZeroHistory.cs
+++ b/Assets/UniStateTests/PlayMode/HistoryTests/Infrastructure/StateInitZeroHistory.cs
@@ -16,7 +16,7 @@ namespace UniStateTests.PlayMode.HistoryTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateInitial.cs
+++ b/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateInitial.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateStartedAfterException.cs
+++ b/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateStartedAfterException.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 

--- a/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateThrowTwoException.cs
+++ b/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateThrowTwoException.cs
@@ -15,14 +15,14 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask Initialize(CancellationToken token)
+        public override UniTask InitializeAsync(CancellationToken token)
         {
             _logger.LogStep("StateThrowTwoException", $"Initialize");
 
             throw new Exception("Initialize exception");
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await UniTask.Yield(token);
 
@@ -31,7 +31,7 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             return Transition.GoTo<StateWithFailExecution>();
         }
 
-        public override UniTask Exit(CancellationToken token)
+        public override UniTask ExitAsync(CancellationToken token)
         {
             _logger.LogStep("StateThrowTwoException", $"Exit");
 

--- a/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateWithFailExecution.cs
+++ b/Assets/UniStateTests/PlayMode/RecoveryTransitionTests/Infrastructure/StateWithFailExecution.cs
@@ -17,7 +17,7 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             _logger = logger;
         }
 
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Disposables.Add(() => { _logger.LogStep("StateWithFailExecution", $"Disposables"); });
 
@@ -33,7 +33,7 @@ namespace UniStateTests.PlayMode.RecoveryTransitionTests.Infrastructure
             throw new Exception("Execution exception");
         }
 
-        public override UniTask Exit(CancellationToken token)
+        public override UniTask ExitAsync(CancellationToken token)
         {
             _logger.LogStep("StateWithFailExecution", $"Exit");
 

--- a/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateFinalFirst.cs
+++ b/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateFinalFirst.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.SubStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Disposables.Add(() => { _logger.LogStep("SubStateFinalFirst", "Disposables"); });
 

--- a/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateFinalSecond.cs
+++ b/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateFinalSecond.cs
@@ -15,7 +15,7 @@ namespace UniStateTests.PlayMode.SubStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Disposables.Add(() => { _logger.LogStep("SubStateFinalSecond", "Disposables"); });
 

--- a/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateInitialFirst.cs
+++ b/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateInitialFirst.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.SubStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Disposables.Add(() => { _logger.LogStep("SubStateInitialFirst", "Disposables"); });
 

--- a/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateInitialSecond.cs
+++ b/Assets/UniStateTests/PlayMode/SubStateTests/Infrastructure/SubStateInitialSecond.cs
@@ -14,7 +14,7 @@ namespace UniStateTests.PlayMode.SubStateTests.Infrastructure
             _logger = logger;
         }
 
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Disposables.Add(() => { _logger.LogStep("SubStateInitialSecond", "Disposables"); });
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Details on installation are available [here](#installation).
 ```csharp
 public class MainMenuState : StateBase
 {
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // Add your state logic here
         return Transition.GoTo<GameplayState>();
@@ -106,7 +106,7 @@ public class MainMenuState : StateBase
 
 public class GameplayState : StateBase
 {
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // Add your state logic here
         return Transition.GoBack();
@@ -138,7 +138,7 @@ Additional information on DI configuration is available [here](#integrations).
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 ```
@@ -239,13 +239,13 @@ outside the scope of UniState.
     {
         private ISimplePopupView _view;
     
-        public override async UniTask Initialize(CancellationToken token) 
+        public override async UniTask InitializeAsync(CancellationToken token) 
         {
             _view = LoadPopupView(token);
             Disposables.Add(UnloadShopView);
         }
     
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             await _view.Show(token);
             await _view.WaitForClick(token);
@@ -253,7 +253,7 @@ outside the scope of UniState.
             return Transition.GoBack();
         }
         
-        public override async UniTask Exit(CancellationToken token)
+        public override async UniTask ExitAsync(CancellationToken token)
         {
             await _view.Hide(token);
         }
@@ -280,7 +280,7 @@ state machine, ensuring they are properly cleaned up after the state machine exi
     // When the StateMachine completes its execution, RootShopPopupState finishes and releases its resources.
     public class RootShopPopupState : StateBase
     {
-        public override async UniTask Initialize(CancellationToken token) 
+        public override async UniTask InitializeAsync(CancellationToken token) 
         {
             // Load ShopView (a Unity GameObject) and create an IDisposable handler that 
             // will unload the GameObject after Disposing. 
@@ -289,13 +289,13 @@ state machine, ensuring they are properly cleaned up after the state machine exi
             Disposables.Add(disposable);
         }
     
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             var stateMachine = StateMachineFactory.Create<StateMachine>();
             
             // Run the internal state machine for ShopPopup.
             // In all states inside this state machine, all resources allocated in this state will be available.
-            await stateMachine.Execute<ShopPopupIdleState>(cts.Token);
+            await stateMachine.ExecuteAsync<ShopPopupIdleState>(cts.Token);
 
             return Transition.GoBack();
         }
@@ -319,7 +319,7 @@ state machine, ensuring they are properly cleaned up after the state machine exi
              _view = view;
         }
     
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             var action = await _view.Show(token);
             
@@ -349,7 +349,7 @@ cases, `StateBase` will suffice.
 // Simple State Inheritance
 public class FooState : StateBase
 {
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // State logic here
     }
@@ -358,7 +358,7 @@ public class FooState : StateBase
 // State with Parameters
 public class FooStateWithPayload : StateBase<FooPayload>
 {
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // Get payload
         FooPayload payload = Payload; 
@@ -370,17 +370,17 @@ public class FooStateWithPayload : StateBase<FooPayload>
 //Custom State Implementation
 public class CustomFooState : IState<MyParams>
 {
-    public async UniTask Initialize(CancellationToken token) 
+    public async UniTask InitializeAsync(CancellationToken token) 
     {
         // Initialization logic
     }
 
-    public async UniTask<StateTransitionInfo> Execute(MyParams payload, CancellationToken token) 
+    public async UniTask<StateTransitionInfo> ExecuteAsync(MyParams payload, CancellationToken token) 
     {
         // Execution logic with payload
     }
 
-    public async UniTask Exit(CancellationToken token)
+    public async UniTask ExitAsync(CancellationToken token)
     {
         // Exit logic
     }
@@ -439,7 +439,7 @@ options are:
 ```csharp
 public class ExampleState : StateBase
 {
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         var transition = await DoSomeAsyncLogic(token);
 
@@ -487,7 +487,7 @@ public class LoadingState : StateBase<ILoadingScreenView>
 {
     private CancellationTokenSource _loadingCts;
 
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // State's disposable references
         _loadingCts = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -527,7 +527,7 @@ This attribute has the following parameters:
   it. This behavior can be useful for states that represent 'loading', there is no point of returning to loading.
 
 - **InitializeOnStateTransition** (default value: false): When enabled, the initialization of the state will begin
-  before exiting the previous state. Technically, this means `Initialize()` of the state will be called before `Exit()`
+  before exiting the previous state. Technically, this means `InitializeAsync()` of the state will be called before `ExitAsync()`
   of the previous state. This behavior can be useful for seamless transitions in complex animations, where the state
   represents only part of the animation.
 
@@ -587,14 +587,14 @@ To use a state machine, resolve it through its interface and invoke `Execute<TIn
 desired entry state.
 
 ```csharp
-await stateMachine.Execute<FooState>(cts.Token);
+await stateMachine.ExecuteAsync<FooState>(cts.Token);
 
 var payload = new BarPayload();
-await stateMachine.Execute<BarState>(payload, cts.Token);
+await stateMachine.ExecuteAsync<BarState>(payload, cts.Token);
 ```
 
 A state machine supports only one active execution flow.  
-Calling `Execute()` again while the current run has not finished raises **`AlreadyExecutingException`** to prevent
+Calling `ExecuteAsync()` again while the current run has not finished raises **`AlreadyExecutingException`** to prevent
 concurrent execution.
 
 You can determine whether the machine is already running by checking property **`IsExecuting`**.
@@ -618,13 +618,13 @@ public class RootGameplayState : StateBase
         _logicMachine = _logicMachine;
     }
 
-    public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+    public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
     {
         // Run UI-related flow in parallel
-        _uiMachine.Execute<UiRootState>(token).Forget();
+        _uiMachine.ExecuteAsync<UiRootState>(token).Forget();
 
         // Run logic and await completion
-        await _logicMachine.Execute<LogicRootState>(token);
+        await _logicMachine.ExecuteAsync<LogicRootState>(token);
 
         return Transition.GoBack();
     }
@@ -693,18 +693,18 @@ public class FooStateMachine : StateMachine
 }
 ```
 
-If an exception is encountered in a state’s `Initialize()` or `Exit()` methods, the state machine will continue working.
-However, if an exception occurs in the state’s `Execute()` method, the state machine defaults to a
+If an exception is encountered in a state's `InitializeAsync()` or `ExitAsync()` methods, the state machine will continue working.
+However, if an exception occurs in the state's `ExecuteAsync()` method, the state machine defaults to a
 `GoBack()` operation, as though `Transition.GoBack()` were returned. You can override this behavior by customizing
 `BuildRecoveryTransition`, which receives an `IStateTransitionFactory` to specify any desired transition for error
 recovery.
 
-When an exception occurs in `Execute()`, `HandleError` will be invoked first, followed by `BuildRecoveryTransition`.
+When an exception occurs in `ExecuteAsync()`, `HandleError` will be invoked first, followed by `BuildRecoveryTransition`.
 
 ```csharp
 public class BarStateMachine : StateMachine
 {
-       // If exception occurs in the state in the Execute() method, the state machine will go to the ErrorPopupState.
+       // If exception occurs in the state in the ExecuteAsync() method, the state machine will go to the ErrorPopupState.
        protected override StateTransitionInfo BuildRecoveryTransition(IStateTransitionFactory transitionFactory)
             => transitionFactory.CreateStateTransition<ErrorPopupState>();
 }
@@ -714,11 +714,11 @@ public class BarStateMachine : StateMachine
 
 During the lifetime of UniState state machine may raise state-machine-specific exceptions:
 
-* **`AlreadyExecutingException`** - derived from `InvalidOperationException`. Thrown when `Execute()` is called while the
+* **`AlreadyExecutingException`** - derived from `InvalidOperationException`. Thrown when `ExecuteAsync()` is called while the
   state machine is already executing, preventing a second concurrent run and indicating an incorrect lifecycle invocation.
 
 * **`NoSubStatesException`** - derived from `InvalidOperationException`. Thrown by `DefaultCompositeState` if its
-  `Execute()` method starts without any SubStates being present.
+  `ExecuteAsync()` method starts without any SubStates being present.
 
 #### Built-in Support for DI Scopes
 
@@ -803,7 +803,7 @@ An example of `ITypeResolver` without DI framework and state machine running:
 
             stateMachine.SetResolver(resolver);
 
-            await stateMachine.Execute<FooState>(CancellationToken.None);
+            await stateMachine.ExecuteAsync<FooState>(CancellationToken.None);
         }
     }
 }
@@ -876,7 +876,7 @@ Each state inherits from **`StateBase`** and returns a transition that drives th
 ```csharp
     internal class StartGameState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Welcome to the game! Your game will be loaded in 2 seconds!");
             await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token);
@@ -888,7 +888,7 @@ Each state inherits from **`StateBase`** and returns a transition that drives th
 ```csharp
     public class RollDiceState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Need to roll 5+. Rolling the dice...");
             await UniTask.Delay(TimeSpan.FromSeconds(2), cancellationToken: token);
@@ -906,7 +906,7 @@ Each state inherits from **`StateBase`** and returns a transition that drives th
 ```csharp
     public class LostState : StateBase
     {
-        public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("You lost. You will have a another chance in...");
 
@@ -926,7 +926,7 @@ Each state inherits from **`StateBase`** and returns a transition that drives th
 ```csharp
     public class WinState : StateBase
     {
-        public override UniTask<StateTransitionInfo> Execute(CancellationToken token)
+        public override UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
         {
             Debug.Log("Congratulations! You won this game!");
             
@@ -952,7 +952,7 @@ StartGameState.
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 ```
@@ -1007,8 +1007,8 @@ change and its direct replacement.
 
 | Removed API                                                | Use Instead                                                                       | Notes                                             |
 |------------------------------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------------------|
-| `StateMachineHelper`                                       | Inject the state machine directly via interface into the state and call `Execute` | Helper no longer required.                        |
-| `StateMachineFactory`                                      | Inject the state machine directly via interface into the state and call `Execute` | Helper no longer required.                        |
+| `StateMachineHelper`                                       | Inject the state machine directly via interface into the state and call `ExecuteAsync` | Helper no longer required.                        |
+| `StateMachineFactory`                                      | Inject the state machine directly via interface into the state and call `ExecuteAsync` | Helper no longer required.                        |
 | `IExecutableStateMachine`                                  | `IStateMachine`                                                                   | Single interface for all operations.              |
 | `RegisterAbstractState` / `BindAbstractState` and variants | `RegisterState<TBase, TImpl>` / `BindState<TBase, TImpl>`                         | Same functionality without the *Abstract* prefix. |
 
@@ -1016,6 +1016,41 @@ change and its direct replacement.
 2. Replace factory/utility calls (`StateMachineHelper`, `StateMachineFactory`) with state machine interface injection.
 3. Update container bindings to the two-parameter `RegisterState` / `BindState` overloads.
 4. Remove references to `IExecutableStateMachine`, use `IStateMachine` everywhere.
+
+### Upgrading from Versions < 1.8.0
+
+The 1.8.0 release introduces proper .NET async naming conventions by adding "Async" suffix to all asynchronous methods. This is a breaking change that requires updating method names throughout your codebase.
+
+| Old Method Name           | New Method Name           | Context                    |
+|---------------------------|---------------------------|----------------------------|
+| `Execute()`               | `ExecuteAsync()`          | State Machine & State      |
+| `Initialize()`            | `InitializeAsync()`       | State                      |
+| `Exit()`                  | `ExitAsync()`             | State                      |
+
+**Migration Steps:**
+
+1. **Update State Machine calls**: Replace all `stateMachine.Execute<>()` calls with `stateMachine.ExecuteAsync<>()`
+2. **Update State implementations**:
+   - Override `ExecuteAsync()` instead of `Execute()`
+   - Override `InitializeAsync()` instead of `Initialize()` (if used)
+   - Override `ExitAsync()` instead of `Exit()` (if used)
+3. **Update custom state implementations**: If implementing `IState<>` directly, update method signatures
+4. **Search and replace**: Use IDE find/replace to update method calls throughout your project
+
+**Example migration:**
+```csharp
+// Before (< 1.8.0)
+public override async UniTask<StateTransitionInfo> Execute(CancellationToken token)
+{
+    // state logic
+}
+
+// After (>= 1.8.0)
+public override async UniTask<StateTransitionInfo> ExecuteAsync(CancellationToken token)
+{
+    // state logic
+}
+```
 
 ## Integrations
 
@@ -1049,7 +1084,7 @@ No extra setup is required - simply resolve the state machine from the DI contai
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 ```
@@ -1105,7 +1140,7 @@ No extra setup is required - simply resolve the state machine from the DI contai
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 ```
@@ -1170,7 +1205,7 @@ namespace Examples.Infrastructure.Reflex
 
         public void Start()
         {
-            _stateMachine.Execute<StartGameState>(CancellationToken.None).Forget();
+            _stateMachine.ExecuteAsync<StartGameState>(CancellationToken.None).Forget();
         }
     }
 }


### PR DESCRIPTION
Implements proper .NET async naming conventions by adding "Async" suffix to all asynchronous methods.
I would suggest bumping major version to address a lot of breaking changes. (current readme updated for migration as 1.8.0 for next version)


**Breaking Changes**

  - IStateMachine.Execute() → ExecuteAsync()
  - IExecutableState.Initialize() → InitializeAsync()
  - IExecutableState.Execute() → ExecuteAsync()
  - IExecutableState.Exit() → ExitAsync()

**Migration**

  See "Upgrading from Versions < 1.8.0" section in README.md for detailed migration steps.

**Files Updated**

  - Core framework interfaces and implementations
  - All examples, tests, and benchmarks
  - Documentation (README.md)

  Fixes #101